### PR TITLE
Revert "Make signing algorithm more explicit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ which can be verified by entering the same string into
 
 Use the private key at `CF_INSTANCE_KEY` to sign the resulting sha
 using the [RSASSA-PSS](https://tools.ietf.org/html/rfc4056) algorithm 
-with a SHA256 hash and a salt length of 20. Random material is injected 
+with a SHA256 hash and a salt length of 222. Random material is injected 
 into this algorithm so the resulting string will be different each time, 
 but here is one example result so you can compare yours to its format:
 ```
@@ -504,11 +504,6 @@ path to CA cert to configure in Vault: /tmp/81701307-8293-71dc-4ffe-d5391d24b1f7
 path to cert to use as CF_INSTANCE_CERT: /tmp/baf26e25-896e-3e5e-f38d-30e5ef1e97d5065686323
 path to key to use as CF_INSTANCE_KEY: /tmp/5c08f79d-b2a5-c211-2862-00fe0a3b647d601276662
 ```
-
-A different example of the approach to signing can be found 
-[here](https://mhmxs.blogspot.com/2018/03/how-to-sign-messages-in-java-and-verify.html),
-a post showing how to sign in Java and verify in Go. The Go code in the example 
-was the basis for the code within this plugin.
 
 ### Quick Start
 

--- a/signatures/version1.go
+++ b/signatures/version1.go
@@ -56,13 +56,13 @@ func Sign(pathToPrivateKey string, signatureData *SignatureData) (string, error)
 	if block == nil {
 		return "", fmt.Errorf("unable to decode RSA private key from %s", keyBytes)
 	}
-	pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	rsaPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
 		return "", err
 	}
 
-	opts := &rsa.PSSOptions{SaltLength: 20}
-	signatureBytes, err := rsa.SignPSS(rand.Reader, pk, crypto.SHA256, signatureData.hash(), opts)
+	// This resolves to using a saltLength of 222.
+	signatureBytes, err := rsa.SignPSS(rand.Reader, rsaPrivateKey, crypto.SHA256, signatureData.hash(), nil)
 	if err != nil {
 		return "", err
 	}
@@ -104,8 +104,7 @@ func Verify(signature string, signatureData *SignatureData) (*x509.Certificate, 
 				result = multierror.Append(result, fmt.Errorf("not an rsa public key, it's a %t", instanceCert.PublicKey))
 				continue
 			}
-			opts := &rsa.PSSOptions{SaltLength: 20}
-			if err := rsa.VerifyPSS(publicKey, crypto.SHA256, signatureData.hash(), signatureBytes, opts); err != nil {
+			if err := rsa.VerifyPSS(publicKey, crypto.SHA256, signatureData.hash(), signatureBytes, nil); err != nil {
 				result = multierror.Append(result, err)
 				continue
 			}


### PR DESCRIPTION
Reverts hashicorp/vault-plugin-auth-pcf#19

I'm actually going to revert this because it turned out to be irrelevant.